### PR TITLE
bug correction for precedence constraints generation

### DIFF
--- a/lib/common/vertex.go
+++ b/lib/common/vertex.go
@@ -84,7 +84,10 @@ func ReadVertexSet(path string) (VertexSet, error) {
 		tempDeadline, _ := strconv.Atoi(record[6])
 		// for successors, we have to first remove the brackets
 		tempSc := record[7][1 : len(record[7])-1]
-		tempSuccessors := strings.Split(tempSc, ",")
+		tempSuccessors := []string{}
+		if len(strings.TrimSpace(tempSc)) != 0 {
+			tempSuccessors = strings.Split(tempSc, ",")
+		}
 
 		var successors []int
 		for _, successor := range tempSuccessors {


### PR DESCRIPTION
The code contained a bug that would always create a precedence constraint from ever sink vertex towards vertex 0 when generating a jobset. The cause is that the split function never return an empty set.